### PR TITLE
Pin build to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - oraclejdk8
+dist: trusty
 env:
   global:
   - DISPLAY=:99.0


### PR DESCRIPTION
TravisCI has migrated to Ubuntu Xenial as a default environment [1].
Oracle JDK 8 is not available on Xenial, therefor we need to pin this
build to Ubuntu Trusty.

[1] https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476