### PR TITLE
remove broken travis build stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/SAP/jcomigrationhelperplugin.svg?branch=master)](https://travis-ci.org/SAP/jcomigrationhelperplugin)
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/jcomigrationhelperplugin)](https://api.reuse.software/info/github.com/SAP/jcomigrationhelperplugin)
 
 # JCo Migration Helper Plugin


### PR DESCRIPTION
This PR removes the broken travis-CI build status from the README. 

After merging this, this will act as well as a "dummy" commit to show that the project is still active.